### PR TITLE
fix: deprecated set-output in GitHub Action workflows

### DIFF
--- a/build/docker/action.yml
+++ b/build/docker/action.yml
@@ -28,7 +28,7 @@ runs:
 
     - id: short-sha
       shell: bash
-      run: echo "::set-output name=sha::$(git rev-parse --short HEAD)"
+      run: echo "sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
     - name: Build, tag, and push image to Amazon ECR
       env:

--- a/deploy/ecs-cron/action.yml
+++ b/deploy/ecs-cron/action.yml
@@ -33,7 +33,7 @@ runs:
 
     - id: short-sha
       shell: bash
-      run: echo "::set-output name=sha::$(git rev-parse --short HEAD)"
+      run: echo "sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
     - name: Deploy Amazon ECS task definition
       env:

--- a/deploy/ecs/action.yml
+++ b/deploy/ecs/action.yml
@@ -33,7 +33,7 @@ runs:
 
     - id: short-sha
       shell: bash
-      run: echo "::set-output name=sha::$(git rev-parse --short HEAD)"
+      run: echo "sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
     - name: Deploy Amazon ECS task definition
       env:


### PR DESCRIPTION
Due to deprecation of `save-state` and `set-output` commands in GitHub Action workflows, this PR should prevent workflows to fail after the 31st May 2023.

Please verify that the workflow is behaving as expected :)

Link to GitHub blogg:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Old way of working
```yaml
- name: Save state
  run: echo "::save-state name={name}::{value}"
- name: Set output
  run: echo "::set-output name={name}::{value}"
```

New way of working
```yaml
- name: Save state
  run: echo "{name}={value}" >> $GITHUB_STATE
- name: Set output
  run: echo "{name}={value}" >> $GITHUB_OUTPUT
```